### PR TITLE
Fix case typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Vue.use(VueMobx, {
 
 import {observable, action} from 'mobx';
 
-Class Test {
+class Test {
     @observable
     count = 0;
 


### PR DESCRIPTION
The example from README wasn't working because of a case typo 😇 